### PR TITLE
Update Godot to 3.5.3 RC 1 (for Flathub Beta)

### DIFF
--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -70,8 +70,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: b43a1d6b29ea25bcbafbcebf7ba0843261aa1237e2739494538a2200d8c7be62
-        url: https://downloads.tuxfamily.org/godotengine/3.5.2/godot-3.5.2-stable.tar.xz
+        sha256: 6069c72a5a06a63b3e9db430fbd53aea7b422d04ebd642561c21b5affadd2828
+        url: https://downloads.tuxfamily.org/godotengine/3.5.3/rc1/godot-3.5.3-rc1.tar.xz
 
       - type: script
         dest-filename: godot.sh


### PR DESCRIPTION
This is for [Flathub Beta](https://discourse.flathub.org/t/how-to-use-flathub-beta/2111). Once 3.5.3 or 3.6 becomes stable, whichever happens first, _that_ stable release will be pushed to the master branch here for [the main Flathub](flathub.org).