### PR TITLE
Update Godot to 3.6 RC 1 (for Flathub Beta)

### DIFF
--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -70,8 +70,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 1e8348e9a3b5d11a60fc4ebf9e72bacc6b96c90828b024660560dbf1ef257962
-        url: https://downloads.tuxfamily.org/godotengine/3.6/beta4/godot-3.6-beta4.tar.xz
+        sha256: d859a0d87fc56d07febcd451909e315b29389acd7a42f3f6e21ab810ab8d65dd
+        url: https://downloads.tuxfamily.org/godotengine/3.6/beta5/godot-3.6-beta5.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -71,7 +71,7 @@ modules:
     sources:
       - type: archive
         sha256: d859a0d87fc56d07febcd451909e315b29389acd7a42f3f6e21ab810ab8d65dd
-        url: https://downloads.tuxfamily.org/godotengine/3.6/beta5/godot-3.6-beta5.tar.xz
+        url: https://github.com/godotengine/godot-builds/releases/download/3.6-beta5/godot-3.6-beta5.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -70,8 +70,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 6069c72a5a06a63b3e9db430fbd53aea7b422d04ebd642561c21b5affadd2828
-        url: https://downloads.tuxfamily.org/godotengine/3.5.3/rc1/godot-3.5.3-rc1.tar.xz
+        sha256: 6703181e130dc48c5f5ba2c612b75e8a9e5859e4ac560b7751ee83ae3b543666
+        url: https://downloads.tuxfamily.org/godotengine/3.6/beta3/godot-3.6-beta3.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -70,8 +70,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: d859a0d87fc56d07febcd451909e315b29389acd7a42f3f6e21ab810ab8d65dd
-        url: https://github.com/godotengine/godot-builds/releases/download/3.6-beta5/godot-3.6-beta5.tar.xz
+        sha256: a9a16a1b448a933d9cd8c5154037e1d2e6eb5203fbbfef842bf4fce22403dbfe
+        url: https://downloads.tuxfamily.org/godotengine/3.6/rc1/godot-3.6-rc1.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -13,6 +13,9 @@ build-options:
         # Only enable link-time optimization when targeting x86_64
         # (causes issues on other architectures)
         SCONS_FLAGS_EXTRA: lto=full
+    aarch64:
+      env:
+        SCONS_FLAGS_EXTRA: arch=arm64
 
   env:
     # Will be appended to the version string displayed in the editor and command-line help

--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -70,8 +70,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 6703181e130dc48c5f5ba2c612b75e8a9e5859e4ac560b7751ee83ae3b543666
-        url: https://downloads.tuxfamily.org/godotengine/3.6/beta3/godot-3.6-beta3.tar.xz
+        sha256: 1e8348e9a3b5d11a60fc4ebf9e72bacc6b96c90828b024660560dbf1ef257962
+        url: https://downloads.tuxfamily.org/godotengine/3.6/beta4/godot-3.6-beta4.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,64 @@
+@@ -1,36 +1,66 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -73,7 +73,9 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  </screenshots>
 +  <content_rating type="oars-1.1" />
 +  <releases>
-+    <release version="3.5.3-rc1" date="2023-09-07"/>
++    <release version="3.6-beta3" date="2023-08-16"/>
++    <release version="3.6-beta2" date="2023-05-24"/>
++    <release version="3.6-beta1" date="2023-04-12"/>
 +    <release version="3.5.2" date="2023-03-07"/>
 +    <release version="3.5.1" date="2022-09-28"/>
 +    <release version="3.5" date="2022-08-06"/>

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,67 @@
+@@ -1,36 +1,68 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -14,6 +14,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  <id>org.godotengine.Godot3</id>
 +  <name>Godot 3</name>
 +  <summary>Godot game engine editor</summary>
++  <launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
    <description>
 -    <p>
 -      Godot is an advanced, feature-packed, multi-platform 2D and 3D game

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -15,7 +15,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  <name>Godot 3</name>
 +  <developer_name>The Godot Engine Community</developer_name>
 +  <summary>Godot game engine editor</summary>
-+  <launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
++  <launchable type="desktop-id">org.godotengine.Godot3.desktop</launchable>
    <description>
 -    <p>
 -      Godot is an advanced, feature-packed, multi-platform 2D and 3D game

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,68 @@
+@@ -1,36 +1,69 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -74,6 +74,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  </screenshots>
 +  <content_rating type="oars-1.1" />
 +  <releases>
++    <release version="3.6-beta5" date="2024-05-07"/>
 +    <release version="3.6-beta4" date="2024-01-24"/>
 +    <release version="3.6-beta3" date="2023-08-16"/>
 +    <release version="3.6-beta2" date="2023-05-24"/>

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,69 @@
+@@ -1,36 +1,70 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -13,6 +13,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 -  ​<launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
 +  <id>org.godotengine.Godot3</id>
 +  <name>Godot 3</name>
++  <developer_name>The Godot Engine Community</developer_name>
 +  <summary>Godot game engine editor</summary>
 +  <launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
    <description>

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,66 @@
+@@ -1,36 +1,67 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -73,6 +73,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  </screenshots>
 +  <content_rating type="oars-1.1" />
 +  <releases>
++    <release version="3.6-beta4" date="2024-01-24"/>
 +    <release version="3.6-beta3" date="2023-08-16"/>
 +    <release version="3.6-beta2" date="2023-05-24"/>
 +    <release version="3.6-beta1" date="2023-04-12"/>

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,70 @@
+@@ -1,36 +1,66 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -75,11 +75,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  </screenshots>
 +  <content_rating type="oars-1.1" />
 +  <releases>
-+    <release version="3.6-beta5" date="2024-05-07"/>
-+    <release version="3.6-beta4" date="2024-01-24"/>
-+    <release version="3.6-beta3" date="2023-08-16"/>
-+    <release version="3.6-beta2" date="2023-05-24"/>
-+    <release version="3.6-beta1" date="2023-04-12"/>
++    <release version="3.6-rc1" date="2024-07-04"/>
 +    <release version="3.5.2" date="2023-03-07"/>
 +    <release version="3.5.1" date="2022-09-28"/>
 +    <release version="3.5" date="2022-08-06"/>


### PR DESCRIPTION
Using TuxFamily publish dates for release dates of 3.6 Betas 1 and 2 in update-appdata.patch, as they were each released a day before their respective blog articles were published

Beta 3's blog article and TuxFamily downloads were both published on the same date