### PR TITLE
Install openjdk separately

### DIFF
--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -1,9 +1,13 @@
 app-id: org.godotengine.Godot3
-runtime: org.freedesktop.Platform
+runtime: org.freedesktop.Sdk
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk11
+add-extensions:
+  org.freedesktop.Sdk.Extension.openjdk17:
+    directory: jdk
+    version: '23.08'
+    no-autodownload: false
+    autodelete: false
 command: godot
 
 build-options:
@@ -48,10 +52,10 @@ finish-args:
 modules:
   - shared-modules/glu/glu-9.json
 
-  - name: openjdk
+  - name: jdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk11/install.sh
+      - mkdir -p /app/jdk
 
   - name: scons
     buildsystem: simple
@@ -71,13 +75,13 @@ modules:
     sources:
       - type: archive
         sha256: 3cb48126b76858f40cf54bd345bb84dc1f49d9e6f8a4a7425ad86e805d39701d
-        url: https://downloads.tuxfamily.org/godotengine/3.5.3/godot-3.5.3-stable.tar.xz
+        url: https://github.com/godotengine/godot/releases/download/3.5.3-stable/godot-3.5.3-stable.tar.xz
 
       - type: script
         dest-filename: godot.sh
         commands:
           - export APPDATA="$XDG_DATA_HOME"
-          - export PATH="/app/jre/bin:$PATH"
+          - if [ -f /app/jdk/enable.sh ]; then source /app/jdk/enable.sh; fi
           - /app/bin/godot-bin "$@"
 
       - type: patch

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,73 @@
+@@ -1,36 +1,74 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -15,6 +15,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  <name>Godot 3</name>
 +  <summary>Godot game engine editor</summary>
 +  <developer_name>The Godot Engine Community</developer_name>
++  <launchable type="desktop-id">org.godotengine.Godot3.desktop</launchable>
    <description>
 -    <p>
 -      Godot is an advanced, feature-packed, multi-platform 2D and 3D game


### PR DESCRIPTION
Based on https://github.com/flathub/org.godotengine.Godot/pull/160, this PR install OpenJDK separately without bundling in Godot flatpak.

While official Godot 3.5/3.6 docs still state to use JDK 11, I saw that in 3.x branch android dependencies has moved from Java 11 to 17 (https://github.com/godotengine/godot/commit/eba77be573793243a91322c7eb8e345695c3b813), I think it is a good chance to update to OpenJdk 17 if there are no known issues, so that both Godot3/Godot4 flatpak can share the same OpenJdk version.