### PR TITLE
Update Godot to 3.6 Beta 1 (for Flathub Beta) (test build)

### DIFF
--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -70,8 +70,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 6069c72a5a06a63b3e9db430fbd53aea7b422d04ebd642561c21b5affadd2828
-        url: https://downloads.tuxfamily.org/godotengine/3.5.3/rc1/godot-3.5.3-rc1.tar.xz
+        sha256: ad2b5a71fa83bd99169f77e940be38b6e1568976b03ff7ed62618989e2c2eda5
+        url: https://downloads.tuxfamily.org/godotengine/3.6/beta1/godot-3.6-beta1.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,64 @@
+@@ -1,36 +1,65 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -73,7 +73,8 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  </screenshots>
 +  <content_rating type="oars-1.1" />
 +  <releases>
-+    <release version="3.5.3-rc1" date="2023-09-07"/>
++    <release version="3.6-beta1" date="2023-04-12"/>
++    <release version="3.5.3" date="2023-09-25"/>
 +    <release version="3.5.2" date="2023-03-07"/>
 +    <release version="3.5.1" date="2022-09-28"/>
 +    <release version="3.5" date="2022-08-06"/>


### PR DESCRIPTION
This is a draft pull request to see if Godot 3.6 Beta 1 builds on Flathub's Buildbot servers. I'm doing this to ensure I know exactly which version the build issues in https://github.com/flathub/org.godotengine.Godot3/pull/5 and https://github.com/godotengine/godot/issues/94182 start at.