### PR TITLE
Update Godot to 3.6

### DIFF
--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -77,8 +77,8 @@ modules:
 
     sources:
       - type: archive
-        sha256: 3cb48126b76858f40cf54bd345bb84dc1f49d9e6f8a4a7425ad86e805d39701d
-        url: https://github.com/godotengine/godot/releases/download/3.5.3-stable/godot-3.5.3-stable.tar.xz
+        sha256: 5bed20a7056d4cc3cca34001752109809ad7ae200548e98c7bbc6afbad18eda7
+        url: https://github.com/godotengine/godot/releases/download/3.6-stable/godot-3.6-stable.tar.xz
 
       - type: script
         dest-filename: godot.sh

--- a/org.godotengine.Godot3.yaml
+++ b/org.godotengine.Godot3.yaml
@@ -17,6 +17,9 @@ build-options:
         # Only enable link-time optimization when targeting x86_64
         # (causes issues on other architectures)
         SCONS_FLAGS_EXTRA: lto=full
+    aarch64:
+      env:
+        SCONS_FLAGS_EXTRA: arch=arm64
 
   env:
     # Will be appended to the version string displayed in the editor and command-line help

--- a/update-appdata.patch
+++ b/update-appdata.patch
@@ -1,7 +1,7 @@
 diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux/org.godotengine.Godot.appdata.xml
 --- a/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-06 14:13:41.000000000 +0000
 +++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml	2023-03-16 22:20:25.946962567 +0000
-@@ -1,36 +1,75 @@
+@@ -1,36 +1,76 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<!-- Copyright 2017-2022 Rémi Verschelde <remi@godotengine.org> -->
  <component type="desktop">
@@ -84,6 +84,7 @@ diff --git a/misc/dist/linux/org.godotengine.Godot.appdata.xml b/misc/dist/linux
 +  </screenshots>
 +  <content_rating type="oars-1.1" />
 +  <releases>
++    <release version="3.6" date="2024-09-09"/>
 +    <release version="3.5.3" date="2023-09-25"/>
 +    <release version="3.5.2" date="2023-03-07"/>
 +    <release version="3.5.1" date="2022-09-28"/>


### PR DESCRIPTION
I have _not_ forgotten about the aarch64 build fix from #5 :+1: